### PR TITLE
Mark tool approvals consumed after terminal execution

### DIFF
--- a/agent_runtimes/guardrails/tool_approvals.py
+++ b/agent_runtimes/guardrails/tool_approvals.py
@@ -1308,6 +1308,20 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
             "result": str(result)[:4000],
             "request": request_payload,
         }
+        try:
+            from agent_runtimes.routes.tool_approvals import _mark_approval_consumed
+
+            await _mark_approval_consumed(
+                agent_id=self.config.agent_id,
+                tool_name=call.tool_name,
+                tool_args=_normalize_tool_args_for_match(args),
+                tool_call_id=tool_call_id,
+                execution_status="success",
+                execution_ref=tool_call_id,
+            )
+        except Exception:
+            logger.debug("[tool-approval] Failed to mark approval consumed", exc_info=True)
+
         self._log_execution_result(result_payload)
         await self._run_tool_hooks(
             phase="after_tool_execute",
@@ -1354,6 +1368,20 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
             "error_type": type(error).__name__,
             "request": request_payload,
         }
+        try:
+            from agent_runtimes.routes.tool_approvals import _mark_approval_consumed
+
+            await _mark_approval_consumed(
+                agent_id=self.config.agent_id,
+                tool_name=call.tool_name,
+                tool_args=_normalize_tool_args_for_match(args),
+                tool_call_id=tool_call_id,
+                execution_status="error",
+                execution_ref=tool_call_id,
+            )
+        except Exception:
+            logger.debug("[tool-approval] Failed to mark approval consumed", exc_info=True)
+
         self._log_execution_result(error_payload)
         await self._run_tool_hooks(
             phase="on_tool_execute_error",

--- a/agent_runtimes/guardrails/tool_approvals.py
+++ b/agent_runtimes/guardrails/tool_approvals.py
@@ -1320,7 +1320,9 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
                 execution_ref=tool_call_id,
             )
         except Exception:
-            logger.debug("[tool-approval] Failed to mark approval consumed", exc_info=True)
+            logger.debug(
+                "[tool-approval] Failed to mark approval consumed", exc_info=True
+            )
 
         self._log_execution_result(result_payload)
         await self._run_tool_hooks(
@@ -1380,7 +1382,9 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
                 execution_ref=tool_call_id,
             )
         except Exception:
-            logger.debug("[tool-approval] Failed to mark approval consumed", exc_info=True)
+            logger.debug(
+                "[tool-approval] Failed to mark approval consumed", exc_info=True
+            )
 
         self._log_execution_result(error_payload)
         await self._run_tool_hooks(

--- a/agent_runtimes/guardrails/tool_approvals.py
+++ b/agent_runtimes/guardrails/tool_approvals.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from pydantic_ai import DeferredToolRequests, RunContext
 from pydantic_ai.capabilities import AbstractCapability
@@ -95,14 +96,16 @@ def _risk_class_for_tool(tool_name: str, args: dict[str, Any]) -> str:
     return "low"
 
 
-def _append_audit_log(path: str, payload: dict[str, Any]) -> None:
+def _append_audit_log(path: str, payload: dict[str, Any]) -> bool:
     try:
         target = Path(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         with target.open("a", encoding="utf-8") as fp:
             fp.write(json_mod.dumps(payload, ensure_ascii=False) + "\n")
+        return True
     except Exception:
         logger.debug("[tool-hooks] Failed to append audit log", exc_info=True)
+        return False
 
 
 def _default_audit_log_path() -> str:
@@ -391,6 +394,17 @@ class ToolApprovalRejectedError(GuardrailBlockedError):
         if note:
             msg += f": {note}"
         super().__init__(msg)
+
+
+class ToolApprovalExecutionReservationError(GuardrailBlockedError):
+    """Raised when an approval cannot be reserved before tool execution."""
+
+    def __init__(self, tool_name: str, approval_id: str | None = None):
+        suffix = f" (approval_id={approval_id})" if approval_id else ""
+        super().__init__(
+            f"Tool '{tool_name}' was blocked because its approval could not be "
+            f"reserved for execution{suffix}"
+        )
 
 
 # ============================================================================
@@ -937,14 +951,59 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
             },
         )
 
-    def _log_execution_result(self, payload: dict[str, Any]) -> None:
-        _append_audit_log(
+    def _log_execution_result(self, payload: dict[str, Any]) -> str | None:
+        execution_ref = f"tool-execution:{uuid4()}"
+        payload["execution_ref"] = execution_ref
+        persisted = _append_audit_log(
             self.config.audit_log_path,
             {
                 "ts": _now_iso(),
                 "event": "tool-execution-result",
                 **payload,
             },
+        )
+        if not persisted:
+            logger.warning(
+                "[tool-approval] Execution result audit receipt could not be persisted"
+            )
+            return None
+        return execution_ref
+
+    async def _reserve_approval_for_execution(
+        self,
+        *,
+        approval_id: str,
+        tool_name: str,
+        safe_args: dict[str, str],
+        tool_call_id: str | None,
+        request_payload: dict[str, Any],
+    ) -> None:
+        from agent_runtimes.routes.tool_approvals import _mark_approval_executing
+
+        try:
+            reserved = await _mark_approval_executing(
+                approval_id,
+                agent_id=self.config.agent_id,
+                tool_name=tool_name,
+                tool_args=safe_args,
+                execution_tool_call_id=tool_call_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[tool-approval] Failed to reserve approval_id=%s before execution",
+                approval_id,
+                exc_info=True,
+            )
+            raise ToolApprovalExecutionReservationError(tool_name, approval_id) from exc
+
+        if reserved is None:
+            raise ToolApprovalExecutionReservationError(tool_name, approval_id)
+
+        self._remember_decision(
+            tool_call_id=tool_call_id,
+            decision="approval-needed",
+            note="approved",
+            request_payload=request_payload,
         )
 
     async def handle_deferred_tool_calls(
@@ -1126,6 +1185,7 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
 
         recent_window_seconds = 120.0
         now = datetime.now(timezone.utc)
+        approval_to_execute: str | None = None
 
         logger.info(
             "[tool-approval] before_tool_execute entered tool='%s' "
@@ -1176,7 +1236,8 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
                             approval.id,
                             tool_call_id,
                         )
-                        return args
+                        approval_to_execute = approval.id
+                        break
                     # tool_call_id matches but still pending — this is the
                     # original outstanding approval for this very call. Bail
                     # out of the loop and go wait on it rather than creating
@@ -1226,7 +1287,8 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
                         approval.id,
                         age_seconds,
                     )
-                    return args
+                    approval_to_execute = approval.id
+                    break
                 else:
                     logger.info(
                         "[tool-approval:dedup] candidate approval_id=%s tool='%s' "
@@ -1237,22 +1299,38 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
                         recent_window_seconds,
                     )
 
+        if approval_to_execute is not None:
+            await self._reserve_approval_for_execution(
+                approval_id=approval_to_execute,
+                tool_name=call.tool_name,
+                safe_args=safe_args,
+                tool_call_id=tool_call_id,
+                request_payload=auth_request,
+            )
+            return args
+
         logger.info(
             "[tool-approval] No dedupe match for tool='%s' tool_call_id=%s — "
             "requesting new approval",
             call.tool_name,
             tool_call_id,
         )
-        await manager.request_and_wait(
+        approval_result = await manager.request_and_wait(
             call.tool_name,
             safe_args,
             tool_call_id,
         )
 
-        self._remember_decision(
+        approval_id = (
+            approval_result.get("id") if isinstance(approval_result, dict) else None
+        )
+        if not isinstance(approval_id, str) or not approval_id:
+            raise ToolApprovalExecutionReservationError(call.tool_name)
+        await self._reserve_approval_for_execution(
+            approval_id=approval_id,
+            tool_name=call.tool_name,
+            safe_args=safe_args,
             tool_call_id=tool_call_id,
-            decision="approval-needed",
-            note="approved",
             request_payload=auth_request,
         )
 
@@ -1308,23 +1386,31 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
             "result": str(result)[:4000],
             "request": request_payload,
         }
-        try:
-            from agent_runtimes.routes.tool_approvals import _mark_approval_consumed
+        execution_ref = self._log_execution_result(result_payload)
+        if execution_ref is not None:
+            try:
+                from agent_runtimes.routes.tool_approvals import _mark_approval_consumed
 
-            await _mark_approval_consumed(
-                agent_id=self.config.agent_id,
-                tool_name=call.tool_name,
-                tool_args=_normalize_tool_args_for_match(args),
-                tool_call_id=tool_call_id,
-                execution_status="success",
-                execution_ref=tool_call_id,
-            )
-        except Exception:
-            logger.debug(
-                "[tool-approval] Failed to mark approval consumed", exc_info=True
-            )
+                consumed = await _mark_approval_consumed(
+                    agent_id=self.config.agent_id,
+                    tool_name=call.tool_name,
+                    tool_args=_normalize_tool_args_for_match(args),
+                    tool_call_id=tool_call_id,
+                    execution_status="success",
+                    execution_ref=execution_ref,
+                )
+                if consumed is None and isinstance(decision_entry, dict):
+                    if decision_entry.get("decision") == "approval-needed":
+                        logger.warning(
+                            "[tool-approval] Executing approval was not found for "
+                            "successful tool_call_id=%s",
+                            tool_call_id,
+                        )
+            except Exception:
+                logger.warning(
+                    "[tool-approval] Failed to mark approval consumed", exc_info=True
+                )
 
-        self._log_execution_result(result_payload)
         await self._run_tool_hooks(
             phase="after_tool_execute",
             payload=result_payload,
@@ -1370,23 +1456,31 @@ class ToolsGuardrailCapability(AbstractCapability[Any]):
             "error_type": type(error).__name__,
             "request": request_payload,
         }
-        try:
-            from agent_runtimes.routes.tool_approvals import _mark_approval_consumed
+        execution_ref = self._log_execution_result(error_payload)
+        if execution_ref is not None:
+            try:
+                from agent_runtimes.routes.tool_approvals import _mark_approval_consumed
 
-            await _mark_approval_consumed(
-                agent_id=self.config.agent_id,
-                tool_name=call.tool_name,
-                tool_args=_normalize_tool_args_for_match(args),
-                tool_call_id=tool_call_id,
-                execution_status="error",
-                execution_ref=tool_call_id,
-            )
-        except Exception:
-            logger.debug(
-                "[tool-approval] Failed to mark approval consumed", exc_info=True
-            )
+                consumed = await _mark_approval_consumed(
+                    agent_id=self.config.agent_id,
+                    tool_name=call.tool_name,
+                    tool_args=_normalize_tool_args_for_match(args),
+                    tool_call_id=tool_call_id,
+                    execution_status="error",
+                    execution_ref=execution_ref,
+                )
+                if consumed is None and isinstance(decision_entry, dict):
+                    if decision_entry.get("decision") == "approval-needed":
+                        logger.warning(
+                            "[tool-approval] Executing approval was not found for "
+                            "failed tool_call_id=%s",
+                            tool_call_id,
+                        )
+            except Exception:
+                logger.warning(
+                    "[tool-approval] Failed to mark approval consumed", exc_info=True
+                )
 
-        self._log_execution_result(error_payload)
         await self._run_tool_hooks(
             phase="on_tool_execute_error",
             payload=error_payload,

--- a/agent_runtimes/routes/tool_approvals.py
+++ b/agent_runtimes/routes/tool_approvals.py
@@ -625,16 +625,13 @@ async def _create_approval(body: ToolApprovalCreateRequest) -> ToolApprovalRecor
     if body.tool_call_id:
         async with _APPROVALS_LOCK:
             for record in _APPROVALS.values():
-                if (
-                    _approval_envelope_matches(
-                        record,
-                        agent_id=body.agent_id,
-                        tool_name=body.tool_name,
-                        tool_args=body.tool_args,
-                        tool_call_id=body.tool_call_id,
-                    )
-                    and record.status not in {"deleted", "consumed"}
-                ):
+                if _approval_envelope_matches(
+                    record,
+                    agent_id=body.agent_id,
+                    tool_name=body.tool_name,
+                    tool_args=body.tool_args,
+                    tool_call_id=body.tool_call_id,
+                ) and record.status not in {"deleted", "consumed"}:
                     # Return an exact-envelope match so continuation turns don't
                     # create a duplicate approval for the same logical call.
                     return record

--- a/agent_runtimes/routes/tool_approvals.py
+++ b/agent_runtimes/routes/tool_approvals.py
@@ -84,6 +84,9 @@ class ToolApprovalRecord(BaseModel):
     tool_call_id: str | None = None
     status: str = "pending"
     note: str | None = None
+    consumed_at: str | None = None
+    execution_status: str | None = None
+    execution_ref: str | None = None
     created_at: str
     updated_at: str
 
@@ -630,7 +633,7 @@ async def _create_approval(body: ToolApprovalCreateRequest) -> ToolApprovalRecor
                         tool_args=body.tool_args,
                         tool_call_id=body.tool_call_id,
                     )
-                    and record.status != "deleted"
+                    and record.status not in {"deleted", "consumed"}
                 ):
                     # Return an exact-envelope match so continuation turns don't
                     # create a duplicate approval for the same logical call.
@@ -784,6 +787,72 @@ async def _update_approval(
             status,
         )
 
+    return updated
+
+
+async def _mark_approval_consumed(
+    *,
+    agent_id: str,
+    tool_name: str,
+    tool_args: Any,
+    tool_call_id: str | None = None,
+    execution_status: str,
+    execution_ref: str | None = None,
+) -> ToolApprovalRecord | None:
+    """Mark the approved envelope as consumed after the tool call reaches a terminal result.
+
+    Approval reuse is useful while a tool call is resuming before execution.
+    Once the tool has actually run, the same approval should not authorize a
+    second side effect.
+    """
+
+    now = _now_iso()
+    async with _APPROVALS_LOCK:
+        candidates = [
+            record
+            for record in _APPROVALS.values()
+            if record.status == "approved"
+            and _approval_envelope_matches(
+                record,
+                agent_id=agent_id,
+                tool_name=tool_name,
+                tool_args=tool_args,
+                tool_call_id=tool_call_id,
+            )
+        ]
+        if not candidates and tool_call_id is None:
+            candidates = [
+                record
+                for record in _APPROVALS.values()
+                if record.status == "approved"
+                and _approval_envelope_matches(
+                    record,
+                    agent_id=agent_id,
+                    tool_name=tool_name,
+                    tool_args=tool_args,
+                )
+            ]
+        if not candidates:
+            return None
+
+        candidates.sort(key=_record_sort_timestamp, reverse=True)
+        record = candidates[0]
+        updated = record.model_copy(
+            update={
+                "status": "consumed",
+                "consumed_at": now,
+                "execution_status": execution_status,
+                "execution_ref": execution_ref,
+                "updated_at": now,
+            }
+        )
+        _APPROVALS[record.id] = updated
+
+    await _publish_approval_event(
+        event_type="tool_approval_consumed",
+        payload=updated.model_dump(),
+        agent_id=updated.agent_id or None,
+    )
     return updated
 
 

--- a/agent_runtimes/routes/tool_approvals.py
+++ b/agent_runtimes/routes/tool_approvals.py
@@ -84,6 +84,8 @@ class ToolApprovalRecord(BaseModel):
     tool_call_id: str | None = None
     status: str = "pending"
     note: str | None = None
+    execution_started_at: str | None = None
+    execution_tool_call_id: str | None = None
     consumed_at: str | None = None
     execution_status: str | None = None
     execution_ref: str | None = None
@@ -631,7 +633,7 @@ async def _create_approval(body: ToolApprovalCreateRequest) -> ToolApprovalRecor
                     tool_name=body.tool_name,
                     tool_args=body.tool_args,
                     tool_call_id=body.tool_call_id,
-                ) and record.status not in {"deleted", "consumed"}:
+                ) and record.status not in {"deleted", "executing", "consumed"}:
                     # Return an exact-envelope match so continuation turns don't
                     # create a duplicate approval for the same logical call.
                     return record
@@ -787,6 +789,47 @@ async def _update_approval(
     return updated
 
 
+async def _mark_approval_executing(
+    approval_id: str,
+    *,
+    agent_id: str,
+    tool_name: str,
+    tool_args: Any,
+    execution_tool_call_id: str | None = None,
+) -> ToolApprovalRecord | None:
+    """Atomically reserve an approved envelope before its tool can execute."""
+
+    now = _now_iso()
+    async with _APPROVALS_LOCK:
+        record = _APPROVALS.get(approval_id)
+        if record is None or record.status != "approved":
+            return None
+        if not _approval_envelope_matches(
+            record,
+            agent_id=agent_id,
+            tool_name=tool_name,
+            tool_args=tool_args,
+        ):
+            return None
+
+        updated = record.model_copy(
+            update={
+                "status": "executing",
+                "execution_started_at": now,
+                "execution_tool_call_id": execution_tool_call_id,
+                "updated_at": now,
+            }
+        )
+        _APPROVALS[approval_id] = updated
+
+    await _publish_approval_event(
+        event_type="tool_approval_execution_started",
+        payload=updated.model_dump(),
+        agent_id=updated.agent_id or None,
+    )
+    return updated
+
+
 async def _mark_approval_consumed(
     *,
     agent_id: str,
@@ -796,7 +839,7 @@ async def _mark_approval_consumed(
     execution_status: str,
     execution_ref: str | None = None,
 ) -> ToolApprovalRecord | None:
-    """Mark the approved envelope as consumed after the tool call reaches a terminal result.
+    """Mark the executing envelope as consumed after the tool call terminates.
 
     Approval reuse is useful while a tool call is resuming before execution.
     Once the tool has actually run, the same approval should not authorize a
@@ -808,27 +851,22 @@ async def _mark_approval_consumed(
         candidates = [
             record
             for record in _APPROVALS.values()
-            if record.status == "approved"
+            if record.status == "executing"
             and _approval_envelope_matches(
                 record,
                 agent_id=agent_id,
                 tool_name=tool_name,
                 tool_args=tool_args,
-                tool_call_id=tool_call_id,
+            )
+            and (
+                tool_call_id is None
+                or record.execution_tool_call_id == tool_call_id
+                or (
+                    record.execution_tool_call_id is None
+                    and record.tool_call_id == tool_call_id
+                )
             )
         ]
-        if not candidates and tool_call_id is None:
-            candidates = [
-                record
-                for record in _APPROVALS.values()
-                if record.status == "approved"
-                and _approval_envelope_matches(
-                    record,
-                    agent_id=agent_id,
-                    tool_name=tool_name,
-                    tool_args=tool_args,
-                )
-            ]
         if not candidates:
             return None
 

--- a/agent_runtimes/tests/test_tool_approvals_route_integration.py
+++ b/agent_runtimes/tests/test_tool_approvals_route_integration.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2025-2026 Datalayer, Inc.
+# Distributed under the terms of the Modified BSD License.
+
+"""Route-level integration test for the tool-approval consumption lifecycle.
+
+Exercises the API-layer path end to end, with no external inference:
+
+    create -> approve -> reserve (approved -> executing)
+    -> tool stub returns "hello (reason: audit)"
+    -> a ``tool-execution:<uuid>`` receipt is persisted
+    -> the envelope reaches terminal ``consumed``
+    -> the same envelope cannot authorize a second side effect.
+
+The create/approve/reserve steps go through the ``routes.tool_approvals``
+entry points (``_create_approval``, the websocket decision helper
+``_decide_approval_via_ws`` -> ``_update_approval``, and
+``_mark_approval_executing``); the receipt + consume step goes through the
+guardrail's real ``after_tool_execute`` hook. No model is called, so the test
+is independent of any inference provider or quota.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic_ai.messages import ToolCallPart
+
+from agent_runtimes.guardrails.tool_approvals import (
+    ToolApprovalConfig,
+    ToolsGuardrailCapability,
+)
+from agent_runtimes.routes.tool_approvals import (
+    _APPROVALS,
+    _APPROVALS_LOCK,
+    ToolApprovalCreateRequest,
+    _create_approval,
+    _decide_approval_via_ws,
+    _mark_approval_consumed,
+    _mark_approval_executing,
+)
+
+_AGENT_ID = "agent-1"
+_TOOL = "runtime_sensitive_echo"
+_TOOL_CALL_ID = "tool-route-1"
+_ARGS = {"text": "hello", "reason": "audit"}
+_STUB_RESULT = "hello (reason: audit)"
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+async def _reset_approvals() -> None:
+    async with _APPROVALS_LOCK:
+        _APPROVALS.clear()
+
+
+@pytest.mark.asyncio
+async def test_route_level_approve_execute_consume_persists_receipt(
+    tmp_path: Path,
+) -> None:
+    """Full API-layer path: approve -> executing -> consumed + receipt, and a
+    consumed envelope can no longer authorize a side effect. No inference."""
+    await _reset_approvals()
+    try:
+        audit_path = tmp_path / "audit.jsonl"
+
+        # 1. Create the pending approval through the route entry point.
+        created = await _create_approval(
+            ToolApprovalCreateRequest(
+                agent_id=_AGENT_ID,
+                tool_name=_TOOL,
+                tool_args=_ARGS,
+                tool_call_id=_TOOL_CALL_ID,
+            )
+        )
+        assert created.status == "pending"
+
+        # 2. Approve it through the websocket decision entry point (which calls
+        #    ``_update_approval``). No JWT credentials are registered, so no
+        #    relay/inference is attempted.
+        approved = await _decide_approval_via_ws(created.id, approved=True, note="approved")
+        assert approved.status == "approved"
+
+        # 3. Reserve the approved envelope (approved -> executing) atomically,
+        #    the write-ahead step that precedes any side effect.
+        reserved = await _mark_approval_executing(
+            created.id,
+            agent_id=_AGENT_ID,
+            tool_name=_TOOL,
+            tool_args=_ARGS,
+            execution_tool_call_id=_TOOL_CALL_ID,
+        )
+        assert reserved is not None
+        assert reserved.status == "executing"
+
+        # 4. The tool runs and the stub returns the echoed value. Drive the
+        #    guardrail's real post-execution hook, which writes the
+        #    ``tool-execution:<uuid>`` receipt and marks the envelope consumed.
+        capability = ToolsGuardrailCapability(
+            config=ToolApprovalConfig(
+                agent_id=_AGENT_ID,
+                audit_log_path=str(audit_path),
+                tools_requiring_approval=["runtime-sensitive-echo"],
+            )
+        )
+        capability._remember_decision(
+            tool_call_id=_TOOL_CALL_ID,
+            decision="approval-needed",
+            note="approved",
+            request_payload={"tool": _TOOL},
+        )
+        returned = await capability.after_tool_execute(
+            None,
+            call=ToolCallPart(
+                tool_name=_TOOL,
+                args=_ARGS,
+                tool_call_id=_TOOL_CALL_ID,
+            ),
+            tool_def=None,
+            args=_ARGS,
+            result=_STUB_RESULT,
+        )
+        assert returned == _STUB_RESULT
+
+        # 5. Terminal state: consumed, with the execution receipt linked.
+        async with _APPROVALS_LOCK:
+            record = _APPROVALS[created.id]
+            assert record.status == "consumed"
+            assert record.consumed_at is not None
+            assert record.execution_status == "success"
+            assert record.execution_ref is not None
+            assert record.execution_ref.startswith("tool-execution:")
+            consumed_ref = record.execution_ref
+
+        # 6. The receipt is durably persisted, is the one linked on the consumed
+        #    envelope, and captured the stub's returned value.
+        receipts = [
+            event
+            for event in _read_jsonl(audit_path)
+            if event.get("event") == "tool-execution-result"
+        ]
+        assert receipts, "expected a persisted tool-execution receipt"
+        assert receipts[-1]["execution_ref"] == consumed_ref
+        assert receipts[-1]["execution_ref"].startswith("tool-execution:")
+        assert receipts[-1]["status"] == "success"
+        assert _STUB_RESULT in receipts[-1]["result"]
+
+        # 7. The same envelope cannot authorize a second side effect: a consumed
+        #    record can be neither re-reserved for execution nor consumed again.
+        second_reserve = await _mark_approval_executing(
+            created.id,
+            agent_id=_AGENT_ID,
+            tool_name=_TOOL,
+            tool_args=_ARGS,
+            execution_tool_call_id="tool-route-2",
+        )
+        assert second_reserve is None
+
+        second_consume = await _mark_approval_consumed(
+            agent_id=_AGENT_ID,
+            tool_name=_TOOL,
+            tool_args=_ARGS,
+            tool_call_id=_TOOL_CALL_ID,
+            execution_status="success",
+            execution_ref="tool-execution:must-not-apply",
+        )
+        assert second_consume is None
+
+        async with _APPROVALS_LOCK:
+            final = _APPROVALS[created.id]
+            assert final.status == "consumed"
+            assert final.execution_ref == consumed_ref
+    finally:
+        await _reset_approvals()

--- a/agent_runtimes/tests/test_tool_approvals_route_integration.py
+++ b/agent_runtimes/tests/test_tool_approvals_route_integration.py
@@ -88,7 +88,9 @@ async def test_route_level_approve_execute_consume_persists_receipt(
         # 2. Approve it through the websocket decision entry point (which calls
         #    ``_update_approval``). No JWT credentials are registered, so no
         #    relay/inference is attempted.
-        approved = await _decide_approval_via_ws(created.id, approved=True, note="approved")
+        approved = await _decide_approval_via_ws(
+            created.id, approved=True, note="approved"
+        )
         assert approved.status == "approved"
 
         # 3. Reserve the approved envelope (approved -> executing) atomically,

--- a/agent_runtimes/tests/test_tools_guardrail_deferred_inline.py
+++ b/agent_runtimes/tests/test_tools_guardrail_deferred_inline.py
@@ -328,3 +328,40 @@ async def test_create_approval_mints_new_record_for_changed_args() -> None:
         assert record.tool_args == {"text": "danger"}
     finally:
         await _reset_approvals()
+
+
+@pytest.mark.asyncio
+async def test_create_approval_does_not_reuse_executing_record() -> None:
+    """An in-flight execution can never authorize a new tool attempt."""
+    await _reset_approvals()
+    try:
+        await _put_record(
+            ToolApprovalRecord(
+                id="approval-create-executing",
+                agent_id="agent-1",
+                pod_name="",
+                tool_name="runtime_sensitive_echo",
+                tool_args={"text": "hello"},
+                tool_call_id="tool-create",
+                status="executing",
+                note=None,
+                execution_started_at=_now_iso(),
+                execution_tool_call_id="tool-create",
+                created_at=_now_iso(),
+                updated_at=_now_iso(),
+            )
+        )
+
+        record = await _create_approval(
+            ToolApprovalCreateRequest(
+                agent_id="agent-1",
+                tool_name="runtime_sensitive_echo",
+                tool_args={"text": "hello"},
+                tool_call_id="tool-create",
+            )
+        )
+
+        assert record.id != "approval-create-executing"
+        assert record.status == "pending"
+    finally:
+        await _reset_approvals()

--- a/agent_runtimes/tests/test_tools_guardrail_tool_hooks.py
+++ b/agent_runtimes/tests/test_tools_guardrail_tool_hooks.py
@@ -471,6 +471,79 @@ async def test_post_tool_hook_runs_on_success_and_clears_cache(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_post_tool_success_consumes_matching_approval(tmp_path: Path) -> None:
+    """After execution, the same approved envelope cannot authorize another side effect."""
+    await _reset_approvals()
+    try:
+        await _put_record(
+            ToolApprovalRecord(
+                id="approval-consume-success",
+                agent_id="agent-1",
+                pod_name="",
+                tool_name="runtime_sensitive_echo",
+                tool_args={"text": "hello"},
+                tool_call_id="tool-consume-1",
+                status="approved",
+                note=None,
+                created_at=_now_iso(),
+                updated_at=_now_iso(),
+            )
+        )
+        capability = ToolsGuardrailCapability(
+            config=ToolApprovalConfig(
+                agent_id="agent-1",
+                audit_log_path=str(tmp_path / "audit.jsonl"),
+                tools_requiring_approval=["runtime-sensitive-echo"],
+            )
+        )
+        capability._remember_decision(
+            tool_call_id="tool-consume-1",
+            decision="approval-needed",
+            note="approved",
+            request_payload={"tool": "runtime_sensitive_echo"},
+        )
+
+        await capability.after_tool_execute(
+            None,
+            call=ToolCallPart(
+                tool_name="runtime_sensitive_echo",
+                args={"text": "hello"},
+                tool_call_id="tool-consume-1",
+            ),
+            tool_def=None,
+            args={"text": "hello"},
+            result={"ok": True},
+        )
+
+        async with _APPROVALS_LOCK:
+            consumed = _APPROVALS["approval-consume-success"]
+            assert consumed.status == "consumed"
+            assert consumed.consumed_at is not None
+            assert consumed.execution_status == "success"
+
+        fake_manager = _FakeManager()
+        capability._manager = cast(ToolApprovalManager, fake_manager)
+        args = {"text": "hello"}
+        result = await capability.before_tool_execute(
+            None,
+            call=ToolCallPart(
+                tool_name="runtime_sensitive_echo",
+                args=args,
+                tool_call_id="tool-consume-2",
+            ),
+            tool_def=None,
+            args=args,
+        )
+
+        assert result == args
+        assert fake_manager.calls == [
+            ("runtime_sensitive_echo", {"text": "hello"}, "tool-consume-2")
+        ]
+    finally:
+        await _reset_approvals()
+
+
+@pytest.mark.asyncio
 async def test_post_tool_hook_runs_on_error_and_clears_cache(tmp_path: Path) -> None:
     audit_path = tmp_path / "audit.jsonl"
     capability = ToolsGuardrailCapability(

--- a/agent_runtimes/tests/test_tools_guardrail_tool_hooks.py
+++ b/agent_runtimes/tests/test_tools_guardrail_tool_hooks.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,6 +16,7 @@ from pydantic_ai.messages import ToolCallPart
 
 from agent_runtimes.guardrails.tool_approvals import (
     ToolApprovalConfig,
+    ToolApprovalExecutionReservationError,
     ToolApprovalManager,
     ToolApprovalRejectedError,
     ToolApprovalTimeoutError,
@@ -24,6 +26,7 @@ from agent_runtimes.routes.tool_approvals import (
     _APPROVALS,
     _APPROVALS_LOCK,
     ToolApprovalRecord,
+    _mark_approval_executing,
 )
 
 _POST_HOOK_PAYLOADS: list[dict[str, Any]] = []
@@ -39,8 +42,9 @@ def mock_post_capture_hook(payload: dict[str, Any], **kwargs: Any) -> dict[str, 
 
 
 class _FakeManager:
-    def __init__(self, requires_approval: bool = True):
+    def __init__(self, requires_approval: bool = True, persist_approval: bool = False):
         self._requires_approval = requires_approval
+        self._persist_approval = persist_approval
         self.calls: list[tuple[str, dict[str, str], str | None]] = []
 
     def requires_approval(self, tool_name: str) -> bool:
@@ -51,8 +55,25 @@ class _FakeManager:
         tool_name: str,
         safe_args: dict[str, str],
         tool_call_id: str | None,
-    ) -> None:
+    ) -> dict[str, str]:
         self.calls.append((tool_name, safe_args, tool_call_id))
+        approval_id = f"fake-approval-{tool_call_id or len(self.calls)}"
+        if self._persist_approval:
+            await _put_record(
+                ToolApprovalRecord(
+                    id=approval_id,
+                    agent_id="agent-1",
+                    pod_name="",
+                    tool_name=tool_name,
+                    tool_args=safe_args,
+                    tool_call_id=tool_call_id,
+                    status="approved",
+                    note=None,
+                    created_at=_now_iso(),
+                    updated_at=_now_iso(),
+                )
+            )
+        return {"status": "approved", "id": approval_id, "tool_name": tool_name}
 
 
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -167,36 +188,120 @@ async def test_pre_tool_inline_python_hook_can_deny(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_pre_tool_approval_needed_requests_wait(tmp_path: Path) -> None:
-    capability = ToolsGuardrailCapability(
-        config=ToolApprovalConfig(
-            agent_id="agent-1",
-            audit_log_path=str(tmp_path / "audit.jsonl"),
-            tools_requiring_approval=["runtime-sensitive-echo"],
-            tool_hooks={
-                "before_tool_execute": [
-                    {"python": ("hook_result = {'decision': 'approval_required'}")}
-                ]
-            },
+    await _reset_approvals()
+    try:
+        capability = ToolsGuardrailCapability(
+            config=ToolApprovalConfig(
+                agent_id="agent-1",
+                audit_log_path=str(tmp_path / "audit.jsonl"),
+                tools_requiring_approval=["runtime-sensitive-echo"],
+                tool_hooks={
+                    "before_tool_execute": [
+                        {"python": ("hook_result = {'decision': 'approval_required'}")}
+                    ]
+                },
+            )
         )
-    )
-    fake_manager = _FakeManager()
-    capability._manager = cast(ToolApprovalManager, fake_manager)
+        fake_manager = _FakeManager(persist_approval=True)
+        capability._manager = cast(ToolApprovalManager, fake_manager)
 
-    args = {"text": "hello", "reason": "audit"}
-    result = await capability.before_tool_execute(
-        None,
-        call=ToolCallPart(
-            tool_name="runtime_sensitive_echo",
+        args = {"text": "hello", "reason": "audit"}
+        result = await capability.before_tool_execute(
+            None,
+            call=ToolCallPart(
+                tool_name="runtime_sensitive_echo",
+                args=args,
+                tool_call_id="tool-approval-1",
+            ),
+            tool_def=None,
             args=args,
-            tool_call_id="tool-approval-1",
-        ),
-        tool_def=None,
-        args=args,
-    )
+        )
 
-    assert result == args
-    assert len(fake_manager.calls) == 1
-    assert fake_manager.calls[0][0] == "runtime_sensitive_echo"
+        assert result == args
+        assert len(fake_manager.calls) == 1
+        assert fake_manager.calls[0][0] == "runtime_sensitive_echo"
+        async with _APPROVALS_LOCK:
+            approval = _APPROVALS["fake-approval-tool-approval-1"]
+            assert approval.status == "executing"
+            assert approval.execution_started_at is not None
+            assert approval.execution_tool_call_id == "tool-approval-1"
+    finally:
+        await _reset_approvals()
+
+
+@pytest.mark.asyncio
+async def test_pre_tool_blocks_when_approval_cannot_be_reserved(
+    tmp_path: Path,
+) -> None:
+    """A manager response without a reservable record must fail closed."""
+    await _reset_approvals()
+    try:
+        capability = ToolsGuardrailCapability(
+            config=ToolApprovalConfig(
+                agent_id="agent-1",
+                audit_log_path=str(tmp_path / "audit.jsonl"),
+                tools_requiring_approval=["runtime-sensitive-echo"],
+            )
+        )
+        capability._manager = cast(ToolApprovalManager, _FakeManager())
+
+        with pytest.raises(ToolApprovalExecutionReservationError):
+            await capability.before_tool_execute(
+                None,
+                call=ToolCallPart(
+                    tool_name="runtime_sensitive_echo",
+                    args={"text": "hello"},
+                    tool_call_id="tool-unreserved",
+                ),
+                tool_def=None,
+                args={"text": "hello"},
+            )
+    finally:
+        await _reset_approvals()
+
+
+@pytest.mark.asyncio
+async def test_execution_reservation_is_atomic() -> None:
+    """Only one concurrent execution can reserve an approved envelope."""
+    await _reset_approvals()
+    try:
+        await _put_record(
+            ToolApprovalRecord(
+                id="approval-race",
+                agent_id="agent-1",
+                pod_name="",
+                tool_name="runtime_sensitive_echo",
+                tool_args={"text": "hello"},
+                tool_call_id="tool-race-original",
+                status="approved",
+                note=None,
+                created_at=_now_iso(),
+                updated_at=_now_iso(),
+            )
+        )
+
+        results = await asyncio.gather(
+            _mark_approval_executing(
+                "approval-race",
+                agent_id="agent-1",
+                tool_name="runtime_sensitive_echo",
+                tool_args={"text": "hello"},
+                execution_tool_call_id="tool-race-a",
+            ),
+            _mark_approval_executing(
+                "approval-race",
+                agent_id="agent-1",
+                tool_name="runtime_sensitive_echo",
+                tool_args={"text": "hello"},
+                execution_tool_call_id="tool-race-b",
+            ),
+        )
+
+        assert sum(result is not None for result in results) == 1
+        async with _APPROVALS_LOCK:
+            assert _APPROVALS["approval-race"].status == "executing"
+    finally:
+        await _reset_approvals()
 
 
 @pytest.mark.asyncio
@@ -244,6 +349,11 @@ async def test_pre_tool_reuses_recent_approval_for_matching_args(
 
         assert result == args
         assert fake_manager.calls == []
+        async with _APPROVALS_LOCK:
+            approval = _APPROVALS["approval-reuse-match"]
+            assert approval.status == "executing"
+            assert approval.execution_started_at is not None
+            assert approval.execution_tool_call_id == "tool-reuse-continuation"
     finally:
         await _reset_approvals()
 
@@ -276,7 +386,7 @@ async def test_pre_tool_does_not_reuse_recent_approval_for_changed_args(
                 tools_requiring_approval=["runtime-sensitive-echo"],
             )
         )
-        fake_manager = _FakeManager()
+        fake_manager = _FakeManager(persist_approval=True)
         capability._manager = cast(ToolApprovalManager, fake_manager)
 
         args = {"text": "danger"}
@@ -416,6 +526,7 @@ async def test_pydantic_before_tool_execute_alias_is_supported(
         args=args,
     )
 
+    assert result == args
     assert fake_manager.calls == []
 
 
@@ -483,8 +594,10 @@ async def test_post_tool_success_consumes_matching_approval(tmp_path: Path) -> N
                 tool_name="runtime_sensitive_echo",
                 tool_args={"text": "hello"},
                 tool_call_id="tool-consume-1",
-                status="approved",
+                status="executing",
                 note=None,
+                execution_started_at=_now_iso(),
+                execution_tool_call_id="tool-consume-1",
                 created_at=_now_iso(),
                 updated_at=_now_iso(),
             )
@@ -520,8 +633,17 @@ async def test_post_tool_success_consumes_matching_approval(tmp_path: Path) -> N
             assert consumed.status == "consumed"
             assert consumed.consumed_at is not None
             assert consumed.execution_status == "success"
+            assert consumed.execution_ref is not None
+            assert consumed.execution_ref != "tool-consume-1"
 
-        fake_manager = _FakeManager()
+        execution_events = [
+            event
+            for event in _read_jsonl(tmp_path / "audit.jsonl")
+            if event.get("event") == "tool-execution-result"
+        ]
+        assert execution_events[-1]["execution_ref"] == consumed.execution_ref
+
+        fake_manager = _FakeManager(persist_approval=True)
         capability._manager = cast(ToolApprovalManager, fake_manager)
         args = {"text": "hello"}
         result = await capability.before_tool_execute(
@@ -593,6 +715,116 @@ async def test_post_tool_hook_runs_on_error_and_clears_cache(tmp_path: Path) -> 
         e.get("event") == "tool-execution-result" and e.get("status") == "error"
         for e in events
     )
+
+
+@pytest.mark.asyncio
+async def test_post_tool_error_consumes_executing_approval(tmp_path: Path) -> None:
+    await _reset_approvals()
+    try:
+        await _put_record(
+            ToolApprovalRecord(
+                id="approval-consume-error",
+                agent_id="agent-1",
+                pod_name="",
+                tool_name="runtime_sensitive_echo",
+                tool_args={"text": "hello"},
+                tool_call_id="tool-error-consume",
+                status="executing",
+                note=None,
+                execution_started_at=_now_iso(),
+                execution_tool_call_id="tool-error-consume",
+                created_at=_now_iso(),
+                updated_at=_now_iso(),
+            )
+        )
+        capability = ToolsGuardrailCapability(
+            config=ToolApprovalConfig(
+                agent_id="agent-1",
+                audit_log_path=str(tmp_path / "audit.jsonl"),
+                tools_requiring_approval=["runtime-sensitive-echo"],
+            )
+        )
+
+        error = RuntimeError("execution failed")
+        returned = await capability.on_tool_execute_error(
+            None,
+            call=ToolCallPart(
+                tool_name="runtime_sensitive_echo",
+                args={"text": "hello"},
+                tool_call_id="tool-error-consume",
+            ),
+            tool_def=None,
+            args={"text": "hello"},
+            error=error,
+        )
+
+        assert returned is error
+        async with _APPROVALS_LOCK:
+            consumed = _APPROVALS["approval-consume-error"]
+            assert consumed.status == "consumed"
+            assert consumed.execution_status == "error"
+            assert consumed.execution_ref is not None
+    finally:
+        await _reset_approvals()
+
+
+@pytest.mark.asyncio
+async def test_terminal_transition_failure_leaves_approval_non_reusable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    await _reset_approvals()
+    try:
+        await _put_record(
+            ToolApprovalRecord(
+                id="approval-stuck-executing",
+                agent_id="agent-1",
+                pod_name="",
+                tool_name="runtime_sensitive_echo",
+                tool_args={"text": "hello"},
+                tool_call_id="tool-stuck",
+                status="executing",
+                note=None,
+                execution_started_at=_now_iso(),
+                execution_tool_call_id="tool-stuck",
+                created_at=_now_iso(),
+                updated_at=_now_iso(),
+            )
+        )
+
+        async def _fail_consumption(**kwargs: Any) -> None:
+            raise RuntimeError("storage unavailable")
+
+        monkeypatch.setattr(
+            "agent_runtimes.routes.tool_approvals._mark_approval_consumed",
+            _fail_consumption,
+        )
+        capability = ToolsGuardrailCapability(
+            config=ToolApprovalConfig(
+                agent_id="agent-1",
+                audit_log_path=str(tmp_path / "audit.jsonl"),
+                tools_requiring_approval=["runtime-sensitive-echo"],
+            )
+        )
+
+        await capability.after_tool_execute(
+            None,
+            call=ToolCallPart(
+                tool_name="runtime_sensitive_echo",
+                args={"text": "hello"},
+                tool_call_id="tool-stuck",
+            ),
+            tool_def=None,
+            args={"text": "hello"},
+            result={"ok": True},
+        )
+
+        async with _APPROVALS_LOCK:
+            assert _APPROVALS["approval-stuck-executing"].status == "executing"
+        assert "Failed to mark approval consumed" in caplog.text
+    finally:
+        await _reset_approvals()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This keeps approval reuse for the pre-execution resume case, but makes the approved envelope terminal once the matching tool call has actually produced a success or error.

Why:

- Before execution, reusing the same approved envelope avoids duplicate prompts during resume/retry plumbing.
- After execution, the same approval should not authorize a second side effect.
- The approval record should carry enough terminal metadata to join approval, execution outcome, and follow-up audit/event handling.

Changes:

- Add consumed_at, execution_status, and execution_ref to ToolApprovalRecord.
- Exclude consumed approvals from exact-envelope reuse when creating/reusing approvals.
- Mark the matching approved envelope consumed from after_tool_execute on success.
- Mark the matching approved envelope consumed from on_tool_execute_error on error.
- Publish a tool_approval_consumed event after consumption.
- Add a focused regression showing a successful tool result consumes the matching approval and a second same-envelope call requests a new approval.

Tested:

- python -m pytest agent_runtimes/tests/test_tools_guardrail_tool_hooks.py::test_post_tool_success_consumes_matching_approval -q
- python -m pytest agent_runtimes/tests/test_tools_guardrail_tool_hooks.py::test_post_tool_hook_runs_on_success_and_clears_cache agent_runtimes/tests/test_tools_guardrail_tool_hooks.py::test_post_tool_hook_runs_on_error_and_clears_cache -q
- python -m pytest agent_runtimes/tests/test_tools_guardrail_tool_hooks.py -q
- git diff --check

Local results:

- 1 passed, 4 warnings
- 2 passed, 4 warnings
- 12 passed, 4 warnings
- git diff --check passed